### PR TITLE
add cliff parameter to vesting contract

### DIFF
--- a/packages/services/src/vesting.rs
+++ b/packages/services/src/vesting.rs
@@ -29,13 +29,32 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct VestingAccount {
     pub address: String,
-    pub schedules: Vec<(u64, u64, Uint128)>,
+    pub schedules: Vec<VestingSchedule>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct VestingInfo {
-    pub schedules: Vec<(u64, u64, Uint128)>,
+    pub schedules: Vec<VestingSchedule>,
     pub last_claim_time: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct VestingSchedule {
+    pub start_time: u64,
+    pub end_time: u64,
+    pub cliff_end_time: u64,
+    pub amount: Uint128,
+}
+
+impl VestingSchedule {
+    pub fn new(start_time: u64, end_time: u64, cliff_end_time: u64, amount: Uint128) -> Self {
+        Self {
+            start_time,
+            end_time,
+            cliff_end_time,
+            amount,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
Add possibility to set `cliff` time. 
For example:
- `vesting start time = 100`
- `vesting end time = 200`
- `vesting amount = 100`

that means every 1 time point new token unlocked. If we add
- `vesting cliff time = 150`

that means user will not be able to claim anything for first 50 time points. But at `point time = 150` he will be able to claim 50 tokens. 